### PR TITLE
Fix image snippet and python conversion

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1,5 +1,6 @@
 //% helper=mapImage
 //% blockIdentity="pixelArt._spriteImage"
+//% pyConvertToTaggedTemplate
 function img(lits: any, ...args: any[]): Image { return null }
 
 namespace helpers {
@@ -253,6 +254,8 @@ namespace pixelArt {
     }
 }
 
+//% snippet='img`.`'
+//% pySnippet='img(""" . """)'
 class Image {
     protected buf: number[];
 


### PR DESCRIPTION
Fixes the dragging out a snippet part in https://github.com/microsoft/pxt-minecraft/issues/2523
Fixes https://github.com/microsoft/pxt-minecraft/issues/2522

Adding annotations to specify the snippet for the Image type and to make sure that the tagged template gets converted correctly from Python.